### PR TITLE
Feature: Support `express-jwt` above version 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,22 @@ class CasualController extends web.AdvancedController {
 }
 ```
 
+**Authenticated Users**
+
 There's a `@User` shorthand which returns the `request.user` object (or `undefined`). The value of the user is usually set in an express middleware such as `express-jwt`.
+
+_Note: `express-jwt` versions below 7 used `request.user`, but from 7+ they use `request.auth`. The `@User` shorthand returns whichever it finds. There's also an `@Auth` that only works with 7+ versions._
 
 ```typescript
 @web.Controller('casual2')
 class CasualController extends web.AdvancedController {
 	@web.Get('another-fancy-function')
 	fancyFunction(@web.User() user?: { id: string }) {
+		console.log(`Gotcha: ${user ? user.id : 'nevermind'}`);
+	}
+
+	@web.Get('latest-fancy-function')
+	fancyFunction(@web.Auth() auth?: { id: string }) {
 		console.log(`Gotcha: ${user ? user.id : 'nevermind'}`);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,5 @@ export * from './methods';
 export * from './middleware';
 export { Permission, Public, Authorize } from './permission';
 export * from './validator';
-export { Req, Res, User, Body, Query, Param } from './params';
+export { Req, Res, User, Auth, Body, Query, Param } from './params';
 export { AdvancedController, AdvancedControllerSettings } from './register';

--- a/src/params.ts
+++ b/src/params.ts
@@ -33,11 +33,21 @@ export function Res(): ActionDecorator {
 	};
 }
 
-/** Binds the `request.user` object. */
+/** Binds the `request.user` object.
+ *  @deprecated Use `Auth()` when using express-jwt > 6.
+*/
 export function User(): ActionDecorator {
 	return (target, propertyKey, parameterIndex) => {
 		const prop = <HttpActionProperty>target[propertyKey];
 		addParam(prop, undefined, parameterIndex, 'user', 'user', false);
+	}
+}
+
+/** Binds the `request.auth` object. */
+export function Auth(): ActionDecorator {
+	return (target, propertyKey, parameterIndex) => {
+		const prop = <HttpActionProperty>target[propertyKey];
+		addParam(prop, undefined, parameterIndex, 'auth', 'auth', false);
 	}
 }
 
@@ -84,7 +94,12 @@ export function resolver(bind: PropBinding, validator?: Validator): (params: any
 	switch (bind.from) {
 		case 'req': return (params: any[], req: Request, res: Response) => { params[bind.index] = req; };
 		case 'res': return (params: any[], req: Request, res: Response) => { params[bind.index] = res; };
-		case 'user': return (params: any[], req: Request, res: Response) => { params[bind.index] = (req as any).user; }
+		/** NOTE: express-jwt changed where decoded JTW is put in versions > 6.
+			Old way: `req.user`
+			New way: `req.auth`
+			More info: https://github.com/auth0/express-jwt#migration-from-v6 */
+		case 'user': return (params: any[], req: Request, res: Response) => { params[bind.index] = (req as any).user || (req as any).auth; }
+		case 'auth': return (params: any[], req: Request, res: Response) => { params[bind.index] = (req as any).auth; }
 
 		// Query or Param: we DON'T have body-parser here, we have to parse manually
 		case 'param':

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { Request, Response, HttpActionProperty, RequestWithUser, WebError, getAllFuncs, Validator } from './types';
+import { Request, Response, HttpActionProperty, RequestWithUserOrAuth, WebError, getAllFuncs, Validator } from './types';
 import { validators } from './validator';
 import { resolver } from './params';
 import { permCheckGenerator, PermCheckResult, setRoleMap } from './permission';
@@ -87,9 +87,9 @@ function generateHandler({
 	autoClose: boolean,
 	thisBind: any,
 	actionFunc: HttpActionProperty,
-	permCheck: (req: RequestWithUser) => Promise<PermCheckResult>,
+	permCheck: (req: RequestWithUserOrAuth) => Promise<PermCheckResult>,
 }) {
-	return async(req: RequestWithUser, res: Response) => {
+	return async(req: RequestWithUserOrAuth, res: Response) => {
 		let params = new Array(argLength);
 		try {
 			// Permission check

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,8 +68,12 @@ export interface Validator {
 	disableAutoClose?: boolean;
 }
 
-export interface RequestWithUser extends Request {
+export interface RequestWithUserOrAuth extends Request {
 	user: {
+		hasPermission?(permission: string): boolean | Promise<boolean>;
+		roles?: string[];
+	};
+	auth: {
 		hasPermission?(permission: string): boolean | Promise<boolean>;
 		roles?: string[];
 	};

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 export { Request, Response } from 'express';
 
 
-export type ParamFrom = 'req' | 'res' | 'user' | 'query' | 'param' | 'body' | 'full-body';
+export type ParamFrom = 'req' | 'res' | 'user' | 'auth' | 'query' | 'param' | 'body' | 'full-body';
 
 export type PropBinding = {
 	index: number;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -6,6 +6,7 @@ export const validators: Validator[] = [
 	{ type: 'req', check: () => true, parse: input => input },
 	{ type: 'res', check: () => true, parse: input => input, disableAutoClose: true },
 	{ type: 'user', check: () => true, parse: input => input },
+	{ type: 'auth', check: () => true, parse: input => input },
 	{ type: String, check: isString, parse: input => input },
 	{ type: Number, check: isNumber, parse: parseInt },
 	{ type: Object, check: isObject, parse: JSON.parse },

--- a/tests/test-auth.ts
+++ b/tests/test-auth.ts
@@ -1,0 +1,51 @@
+import { assert } from 'chai';
+import * as web from '../dist/index';
+import { app, baseUrl, assertStatusCode } from './test-base';
+import * as request from 'request';
+
+
+interface Auth {
+	id: number;
+}
+
+
+@web.Controller('auth-test')
+@web.Public()
+class UserController extends web.AdvancedController {
+	@web.Get('ok')
+	ok(@web.Auth() auth: Auth): Auth { return auth; }
+
+	@web.Get('not-ok')
+	notOk(@web.Auth() auth: Auth): Auth { return auth; }
+}
+
+
+describe('Auth binding', () => {
+	before(() => {
+		app.use('/auth-test/ok', (req, _res, next) => {
+			(req as any).auth = { id: 43 };
+			next();
+		});
+		const mainController = new UserController();
+		mainController.register(app, { implicitAccess: true });
+	});
+
+	it('should have auth at the good path', (done) => {
+		request(baseUrl + 'auth-test/ok', (error, response, body) => {
+			assertStatusCode(error, response);
+			const data = JSON.parse(body);
+			assert.ok(data);
+			assert.equal(data.id, 43);
+			done();
+		});
+	});
+
+	it('should not have auth at the other path', (done) => {
+		request(baseUrl + 'auth-test/not-ok', (error, response, body) => {
+			assertStatusCode(error, response);
+			assert.equal(body, 'OK')
+			done();
+		});
+	});
+
+});

--- a/tests/test-user.ts
+++ b/tests/test-user.ts
@@ -17,6 +17,9 @@ class UserController extends web.AdvancedController {
 
 	@web.Get('not-ok')
 	notOk(@web.User() user: User): User { return user; }
+
+	@web.Get('ok-fallback-to-auth')
+	okFallbackToAuth(@web.User() user: User): User { return user; }
 }
 
 
@@ -26,12 +29,26 @@ describe('User binding', () => {
 			(req as any).user = { id: 43 };
 			next();
 		});
+		app.use('/user-test/ok-fallback-to-auth', (req, _res, next) => {
+			(req as any).auth = { id: 43 };
+			next();
+		});
 		const mainController = new UserController();
 		mainController.register(app, { implicitAccess: true });
 	});
 
 	it('should have user at the good path', (done) => {
 		request(baseUrl + 'user-test/ok', (error, response, body) => {
+			assertStatusCode(error, response);
+			const data = JSON.parse(body);
+			assert.ok(data);
+			assert.equal(data.id, 43);
+			done();
+		});
+	});
+
+	it('should have user at the good path as fallback to `auth`', (done) => {
+		request(baseUrl + 'user-test/ok-fallback-to-auth', (error, response, body) => {
 			assertStatusCode(error, response);
 			const data = JSON.parse(body);
 			assert.ok(data);

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -3,6 +3,7 @@ require('./test-mw');
 require('./test-methods');
 require('./test-bindings');
 require('./test-user');
+require('./test-auth');
 require('./test-returns');
 require('./test-special');
 require('./test-permission');


### PR DESCRIPTION
In `express-jwt` > 6, the `req.user` is changed to `req.auth`, so every `@User()` annotation is broken. :cry: 

- This PR adds a new `@Auth()` decorator, that uses the `req.auth`.
- To avoid refactoring all dependent libraries and applications, it also adds `req.auth` as a fallback of `req.user`, when using `@User()`.
- Tests added & updated.